### PR TITLE
Fix prompt symbols limit renewal date

### DIFF
--- a/apps/platform/app/api/auth/signup/route.ts
+++ b/apps/platform/app/api/auth/signup/route.ts
@@ -16,7 +16,7 @@ export const POST = async (req: Request) => {
     data: {
       email,
       password: hashed,
-      promptSymbolsLimitRenewal: new Date(),
+      promptSymbolsLimitRenewal: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), // 30 days from now
       promptSymbolsLimit: 2500,
     },
   });


### PR DESCRIPTION
Set `promptSymbolsLimitRenewal` to 30 days in the future for new users to prevent immediate expiration.